### PR TITLE
Initial gitops install of chains plus simple demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 hack/preview.env
+cosign.pub

--- a/components/build/README.md
+++ b/components/build/README.md
@@ -6,6 +6,7 @@ The App Studio Build System is composed of the following components:
 1. OpenShift Pipelines. 
 2. AppStudio-specific Pipeline Definitions in `build-templates` for building images.
 3. AppStudio-specific `ClusterTasks`.
+4. Tekton Chains.
 
 This repository installs all the components and includes a set of example scripts that simplify usage and provide examples of a working system. There are no additiona components needed to use the build system API, howvever some utilities and scripts are provided to demonstrate functionality. 
 

--- a/components/build/kustomization.yaml
+++ b/components/build/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - openshift-pipelines/
 - build-templates/ 
 - pipelines-as-code/
+- tekton-chains/
 
 generatorOptions:
  disableNameSuffixHash: true

--- a/components/build/tekton-chains/chains-config.yaml
+++ b/components/build/tekton-chains/chains-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-config
+  namespace: tekton-chains
+
+data:
+  # See https://tekton.dev/docs/chains/config/
+  artifacts.taskrun.format: "in-toto"
+
+  # The internal openshift image registry can handle storing
+  # taskrun attestations with oci, but quay.io can't. So currently
+  # we need to change this to "tekton" for quay.io registries.
+  artifacts.taskrun.storage: "oci"
+
+  # For image signing iiuc
+  artifacts.oci.storage: "oci"
+
+  # We might want to turn this off by default later so we aren't
+  # filling up rekor.sigstore.dev with garbage.
+  transparency.enabled: "true"
+  #transparency.url: "https://rekor.sigstore.dev"

--- a/components/build/tekton-chains/kustomization.yaml
+++ b/components/build/tekton-chains/kustomization.yaml
@@ -9,8 +9,12 @@ resources:
 - https://storage.googleapis.com/tekton-releases/chains/previous/v0.8.0/release.yaml
 
 patchesStrategicMerge:
+#
 # Add some chains configuration
 - chains-config.yaml
+#
+# Remove runAsUser and runAsGroup from security context
+- security-context-fix.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/build/tekton-chains/kustomization.yaml
+++ b/components/build/tekton-chains/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+#
+# For now we'll use the official release directly rather than downloading
+# it and checking it in.
+#
+# To list available releases:
+#  curl -s https://storage.googleapis.com/tekton-releases/ | xq | grep -E 'chains/.*/release.yaml'
+#
+- https://storage.googleapis.com/tekton-releases/chains/previous/v0.8.0/release.yaml
+
+patchesStrategicMerge:
+# Add some chains configuration
+- chains-config.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/build/tekton-chains/security-context-fix.yaml
+++ b/components/build/tekton-chains/security-context-fix.yaml
@@ -1,0 +1,28 @@
+#
+# The default install of chains includes the following
+# which (iiuc) works in kubernetes but not openshift.
+#
+#    # User 65532 is the distroless nonroot user ID
+#    runAsUser: 65532
+#    runAsGroup: 65532
+#
+# The suggested workaround is to run this command:
+#   oc adm policy add-scc-to-user anyuid -z tekton-chains-controller
+#
+# but instead of that workaround we'll remove the runAsUser and
+# runAsGroup config.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-chains-controller
+  namespace: tekton-chains
+spec:
+  template:
+    spec:
+      containers:
+      - name: tekton-chains-controller
+        securityContext:
+          # Clear these two fields
+          runAsGroup:
+          runAsUser:

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -62,6 +62,11 @@ fi
 ARGO_CD_URL="https://$(kubectl get route/openshift-gitops-server -n openshift-gitops -o template --template={{.spec.host}})"
 
 echo
+echo "Configuring service account for Tekton Chains:"
+oc new-project tekton-chains
+oc adm policy add-scc-to-user anyuid -z tekton-chains-controller
+
+echo
 echo "========================================================================="
 echo
 echo "Argo CD URL is: $ARGO_CD_URL"

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -62,11 +62,6 @@ fi
 ARGO_CD_URL="https://$(kubectl get route/openshift-gitops-server -n openshift-gitops -o template --template={{.spec.host}})"
 
 echo
-echo "Configuring service account for Tekton Chains:"
-oc new-project tekton-chains
-oc adm policy add-scc-to-user anyuid -z tekton-chains-controller
-
-echo
 echo "========================================================================="
 echo
 echo "Argo CD URL is: $ARGO_CD_URL"

--- a/hack/chains/README.md
+++ b/hack/chains/README.md
@@ -1,0 +1,58 @@
+# hack/chains
+
+Some bash scripts to help configure and demonstrate [Tekton
+Chains](https://github.com/tektoncd/chains) in an infra-deployments managed
+cluster.
+
+## To set up an environment from scratch
+
+### Bootstrap
+
+For CRC users:
+
+    crc delete
+    crc start
+    `crc console --credentials | tail -1 | cut -d\' -f2`
+
+Then (assuming you're in this branch on your own fork):
+
+    hack/bootstrap-cluster.sh preview
+
+A "go make some coffee" one liner:
+
+    crc delete; crc start; `crc console --credentials | tail -1 | cut -d\' -f2`; hack/bootstrap-cluster.sh preview
+
+Wait a while until you see mostly healthy/synced at [Argo CD](https://openshift-gitops-server-openshift-gitops.apps-crc.testing/applications).
+
+(I have degraded 'has' and 'spi' related to GitHub auth and I don't think it
+matters for the basic pipeline functionality needed to do builds and
+demonstrate chains.)
+
+### Create a key-pair signing secret for chains
+
+    cd hack/chains
+    ./create-signing-secret.sh
+
+### Apply some CA cert related hacks to make SSL work
+
+    ./trust-local-cert.sh
+    ./setup-controller-certs.sh
+
+## Demos
+
+### Kaniko build demo
+
+Currently this works well in a local CRC cluster, but has some problems
+running on a cluster-bot cluster in AWS.
+
+    ./kaniko-demo-build.sh
+    ./kaniko-demo-cosign.sh
+    ./kaniko-demo-rekor.sh
+
+### S2I pipeline build demo
+
+Todo
+
+### Buildah pipeline build demo
+
+Todo

--- a/hack/chains/_helpers.sh
+++ b/hack/chains/_helpers.sh
@@ -1,0 +1,21 @@
+
+title() {
+  echo
+  echo "🔗 ---- $* ----"
+}
+
+pause() {
+  echo
+  local MSG="$*"
+  [[ -z "$MSG" ]] && MSG="Hit enter to continue..."
+  read -p "$MSG"
+}
+
+show-then-run() {
+  read -p "\$ $*"
+  $*
+}
+
+curl-json() {
+  curl -s -H "Accept: application/json" $@
+}

--- a/hack/chains/check-pipelinerun.sh
+++ b/hack/chains/check-pipelinerun.sh
@@ -2,22 +2,15 @@
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-PIPELINERUN_NAME=$1
-
 # Preserve sanity while hacking
-set -ue
+set -u
 
-if [[ -z $PIPELINERUN_NAME ]]; then
-  # Use the most recently created pipelinerun
-  # (Fixme: Would be better to exclude running pipelines)
-  PIPELINERUN_NAME=$(
-    kubectl get pipelinerun -o name --sort-by=.metadata.creationTimestamp |
-      tail -1 | cut -d/ -f2 )
-fi
+# Use a specific pipelinerun if provided, otherwise use the latest
+PIPELINERUN_NAME=${1:-$( tkn pipelinerun describe --last -o name )}
+PIPELINERUN_NAME=pipelinerun/$( echo $PIPELINERUN_NAME | sed 's#.*/##' )
 
 TASKRUN_NAMES=$(
-  kubectl get pipelinerun/$PIPELINERUN_NAME -o yaml |
-    yq e '.status.taskRuns | keys | .[]' - )
+  kubectl get $PIPELINERUN_NAME -o yaml | yq e '.status.taskRuns | keys | .[]' - )
 
 for name in $TASKRUN_NAMES; do
   echo -n "$name 🔗 "

--- a/hack/chains/create-signing-secret.sh
+++ b/hack/chains/create-signing-secret.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Show a message and exit gracefully if cosign isn't installed
+! which cosign >/dev/null 2>&1 && echo "Please install cosign!" && exit
+
+# Once the key-pair has been set it's marked as immutable so it can't be updated.
+# Try to handle that nicely. The object is expected to always exist so check the data.
+SIG_KEY_DATA=$(kubectl get secret signing-secrets -n tekton-chains -o jsonpath='{.data}')
+[[ -n $SIG_KEY_DATA ]] && echo "Signing secret exists." && exit
+
+# Ensure the cosign.pub key file ends up in a consistent place, i.e. the
+# top level directory of this git repo
+cd "$( dirname "${BASH_SOURCE[0]}" )/../.."
+
+# To make this run conveniently without user input let's create a random password
+RANDOM_PASS=$( head -c 12 /dev/urandom | base64 )
+
+# Generates the key pair secret directly in the cluster. Also creates public key file cosign.pub
+env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair k8s://tekton-chains/signing-secrets
+
+# Uncomment if you want to show the secret
+#kubectl get secret signing-secrets -n tekton-chains -o yaml | yq e . -

--- a/hack/chains/kaniko-demo-build.sh
+++ b/hack/chains/kaniko-demo-build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/_helpers.sh
+set -ue
+
+echo "To watch the chains controller logs:"
+echo "  kubectl logs -f -l app=tekton-chains-controller -n tekton-chains"
+pause
+
+title "Set project"
+# Todo: Make it work in any project
+oc project tekton-chains
+
+title "Ensure we have the demo kaniko build task"
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/chains/main/examples/kaniko/kaniko.yaml
+
+# Tweak it to avoid TLS failures
+# Fixme: Make it work without --skip-tls-verify
+kubectl patch task/kaniko-chains --type=json \
+  --patch='[{"op": "add", "path": "/spec/steps/1/args/5", "value":"--skip-tls-verify=true"}]'
+
+IMAGE_REGISTRY=$( oc registry info )
+DOCKERCFG=$( oc get sa tekton-chains-controller -o json | jq -r '.secrets[1].name' )
+
+title "Run a build task and watch it"
+tkn task start kaniko-chains \
+  --param IMAGE=$IMAGE_REGISTRY/tekton-chains/kaniko-chains \
+  --use-param-defaults \
+  --workspace name=source,emptyDir= \
+  --workspace name=dockerconfig,secret=$DOCKERCFG \
+  --showlog

--- a/hack/chains/kaniko-demo-cosign.sh
+++ b/hack/chains/kaniko-demo-cosign.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/_helpers.sh
+set -ue
+
+# Use a specific taskrun if provided, otherwise use the latest
+TASKRUN_NAME=${1:-$( tkn taskrun describe --last -o name )}
+TASKRUN_NAME=taskrun/$( echo $TASKRUN_NAME | sed 's#.*/##' )
+
+# Let's not hard code the image url or the registry
+IMAGE_URL=$( oc get $TASKRUN_NAME -o json | jq -r '.status.taskResults[1].value' )
+IMAGE_REGISTRY=$( echo $IMAGE_URL | cut -d/ -f1 )
+#IMAGE_REGISTRY=$( oc registry info )
+
+SIG_KEY="k8s://tekton-chains/signing-secrets"
+
+# Make sure we have a docker credential since cosign will need it
+# (Todo: Probably shouldn't assume kubeadmin user here)
+oc whoami -t | docker login -u kubeadmin --password-stdin $IMAGE_REGISTRY
+
+title "Inspecting $TASKRUN_NAME metadata"
+echo "(Beware long lines are truncated)"
+# Just want to show the chains related fields
+# Truncating to avoid a whole screen full of base64 encoded data
+oc get $TASKRUN_NAME -o yaml | yq e .metadata -C - | cut -c -150
+pause
+
+title "Cosign verify the image"
+# Save the output data to a file so we can look at it later
+show-then-run "cosign verify --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify.out"
+pause
+
+# The output files are json, but let's show as yaml for readability
+
+title "Inspect the cosign verify output"
+yq e . -P /tmp/verify.out
+pause
+
+title "Cosign verify the image's attestation"
+show-then-run "cosign verify-attestation --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify-att.out"
+pause
+
+# If you build the same build more than once there will be multiple
+# attestations and hence multiple lines in this file, which makes it
+# invalid json. For the sake of the demo we'll be lazy and ignore
+# all but the last line.
+#
+title "Inspect the cosign verify attestation output"
+tail -1 /tmp/verify-att.out | yq e . -P -
+pause
+
+title "Inspect the payload from that attestation output"
+tail -1 /tmp/verify-att.out | yq e .payload - | base64 -d | yq e . -P -

--- a/hack/chains/kaniko-demo-rekor.sh
+++ b/hack/chains/kaniko-demo-rekor.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/_helpers.sh
+set -ue
+
+# Use a specific taskrun if provided, otherwise use the latest
+TASKRUN_NAME=${1:-$( tkn taskrun describe --last -o name )}
+TASKRUN_NAME=taskrun/$( echo $TASKRUN_NAME | sed 's#.*/##' )
+
+# Let's not hard code the image url or the registry
+IMAGE_URL=$( oc get $TASKRUN_NAME -o json | jq -r '.status.taskResults[1].value' )
+IMAGE_REGISTRY=$( echo $IMAGE_URL | cut -d/ -f1 )
+
+TRANSPARENCY_URL=$(
+  oc get $TASKRUN_NAME -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/transparency}' )
+
+# Extract the log index from the url
+LOG_INDEX=$( echo $TRANSPARENCY_URL | cut -d= -f2 )
+
+# In the future we might use our own rekor servers, so let's not hard code that
+REKOR_SERVER=$( echo $TRANSPARENCY_URL | cut -d/ -f1-3 )
+
+title "Transparency url for $TASKRUN_NAME found in the annotations"
+echo $TRANSPARENCY_URL
+pause
+
+title "Take a look at it"
+curl-json $TRANSPARENCY_URL | yq e . -P -
+pause
+
+title "Extract the rekor body"
+curl -s -H "Accept: application/json" $TRANSPARENCY_URL | jq -r 'values[].body' | base64 -d | yq e . -PC -
+pause
+
+# Comment this out because there is no attestation data in the kaniko build task
+#title "Extract the rekor attestation"
+#curl -s -H "Accept: application/json" $TRANSPARENCY_URL | jq -r 'values[].attestation.data' | base64 -d | base64 -d | yq e . -PC -
+#pause
+
+title "Using the rekor-cli"
+show-then-run "rekor-cli get --log-index $LOG_INDEX --rekor_server $REKOR_SERVER"
+pause
+
+title "There's also a --format json option:"
+rekor-cli get --log-index $LOG_INDEX --rekor_server $REKOR_SERVER --format json | yq e . -P -
+pause
+
+title "Try a rekor-cli verify"
+show-then-run "rekor-cli verify --log-index $LOG_INDEX --rekor_server $REKOR_SERVER"

--- a/hack/chains/setup-controller-certs.sh
+++ b/hack/chains/setup-controller-certs.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Based on Christophe's procedure to get working SSL in a
+# local CRC cluster so the chains signed provenance demo works.
+# See https://docs.engineering.redhat.com/x/zFp-Dw .
+#
+# This is a temporary workaround. There should be a better way to
+# ensure the chains controller has access a set of CA certs -
+# maybe with https://cert-manager.io/ , or maybe the certs are
+# available already somewhere else in the cluster and just need
+# to be exposed to the chains controller.
+#
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/_helpers.sh
+set -u
+
+TMP_DIR=$( mktemp -d )
+
+#
+# First prepare some CA certs and create a secret to hold them
+#
+
+# A cert from your local cluster to get local SSL working
+kubectl get secret router-ca -n openshift-ingress-operator -o jsonpath="{.data.tls\.crt}" | base64 -d > $TMP_DIR/cluster-ingress.pem
+
+# Certs from your laptop to get SSL working on the internet
+cp /etc/ssl/cert.pem $TMP_DIR/cert.pem
+
+CREATE_OR_REPLACE=create
+kubectl get secret chains-ca-cert -n tekton-chains >/dev/null 2>&1 && CREATE_OR_REPLACE=replace
+
+# Put them all together in a secret
+# (Use sed for yaml indenting)
+# (FYI we can't use apply here because the data is too big for the annotation field)
+cat << EOF | kubectl $CREATE_OR_REPLACE -n tekton-chains -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chains-ca-cert
+data:
+  ca-certificates.crt: |
+$( cat $TMP_DIR/*.pem | base64 | sed 's/^/    /' )
+EOF
+
+# Uncomment if you want to show all the certs:
+#kubectl get secret chains-ca-cert -n tekton-chains -o jsonpath='{.data.ca-certificates\.crt}' | base64 -d
+
+#
+# Now make the certs accessible where they're needed
+#
+
+PATCH_YAML="
+spec:
+  template:
+    spec:
+      containers:
+      - name: tekton-chains-controller
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: chains-ca-cert
+      volumes:
+      - name: chains-ca-cert
+        secret:
+          secretName: chains-ca-cert
+"
+kubectl patch deployment tekton-chains-controller -n tekton-chains --patch "$PATCH_YAML"
+
+# Cleanup
+rm -rf $TMP_DIR

--- a/hack/chains/trust-local-cert.sh
+++ b/hack/chains/trust-local-cert.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Make your laptop trust the local cluster's SSL cert.
+#
+# Probably only needed for a CRC cluster running locally.
+#
+# Actually cosign does have an --allow-insecure-registry option but
+# trusting this cert means we don't have to use it, and I think it makes
+# things easier generally for registry auth.
+#
+kubectl get secret router-ca -n openshift-ingress-operator -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/cluster-ingress.pem
+sudo cp /tmp/cluster-ingress.pem /etc/pki/ca-trust/source/anchors
+sudo update-ca-trust

--- a/hack/destroy-cluster.sh
+++ b/hack/destroy-cluster.sh
@@ -5,6 +5,8 @@ TOOLCHAIN_E2E_TEMP_DIR=/tmp/toolchain-e2e
 
 # Remove resources in the reverse order from bootstrapping
 
+# Todo: Is there anything related to tekton-chains that needs removing here?
+
 echo
 echo "Remove Argo CD Applications:"
 kubectl delete -f $ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml


### PR DESCRIPTION
Includes:
* Gitops config to install chains
* A script to help create a signing secret
* Scripts to help configure CA certs to get SSL working for chains
* Scripts to help demo chains, cosign and rekor-cli with a simple kaniko build task

Caveats/Todo:
* It doesn't work smoothly in a cluster-bot cluster
* There are some scripts you need to run after the gitops sync is done
* The demo uses the internal image registry rather than quay.io
* Demo doesn't cover S2I or Buildah builds

All these things can be addressed later - they're not considered blockers for merging this into the contract-devel branch.

Jiras:
* [HACBS-38](https://issues.redhat.com/browse/HACBS-38)
* [HACBS-47](https://issues.redhat.com/browse/HACBS-47)