### PR TITLE
Fix yp call

### DIFF
--- a/hack/chains/kaniko-cosign-verify.sh
+++ b/hack/chains/kaniko-cosign-verify.sh
@@ -35,7 +35,7 @@ title "Cosign verify the image"
 # Save the output data to a file so we can look at it later
 # (Actually we could just pipe it to jq because the text goes to stderr I think..?)
 show-then-run "cosign verify --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify.out"
-yq e -P /tmp/verify.out
+cat /tmp/verify.out | yq e . -P -
 pause
 
 title "Cosign verify the image's attestation"

--- a/hack/chains/kaniko-cosign-verify.sh
+++ b/hack/chains/kaniko-cosign-verify.sh
@@ -35,7 +35,7 @@ title "Cosign verify the image"
 # Save the output data to a file so we can look at it later
 # (Actually we could just pipe it to jq because the text goes to stderr I think..?)
 show-then-run "cosign verify --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify.out"
-cat /tmp/verify.out | yq e . -P -
+yq e . -P - < /tmp/verify.out
 pause
 
 title "Cosign verify the image's attestation"


### PR DESCRIPTION
On some Fedora distributions, yp is installed via snapd and has
issues accessing files in some locations when called directly.
This PR pipes the output of the /tmp/verify.out file to yp to
address this.