### PR TITLE
Add support for enable/disable local rekor

### DIFF
--- a/hack/chains/config.sh
+++ b/hack/chains/config.sh
@@ -92,10 +92,16 @@ case "$1" in
 
   remove-key )
     # Remove the given key from the data section
-    set -x
-    kubectl patch $CHAINS_CONFIG --type=json -p='[{"op": "remove", "path":"'"/data/$2"'"}]'
-    $0 restart-controller
-    $0 get
+    PATCH=$(echo '[{"op": "remove", "path":"'"/data/$2"'"}]' | yq -o=json --indent=0 e - )
+
+    if [[ $3 == '--dry-run' ]]; then
+      echo "$PATCH" | yq e -P 'sort_keys(..)' -
+    else
+      set -x
+      kubectl patch $CHAINS_CONFIG --type=json -p='[{"op": "remove", "path":"'"/data/$2"'"}]'
+      $0 restart-controller
+      $0 get
+    fi
 
     ;;
 

--- a/hack/chains/config.sh
+++ b/hack/chains/config.sh
@@ -91,14 +91,12 @@ case "$1" in
     ;;
 
   remove-key )
-    # Remove the given key from the data section
-    PATCH=$(echo '[{"op": "remove", "path":"'"/data/$2"'"}]' | yq -o=json --indent=0 e - )
-
+    PATCH=$(echo "[{"op": "remove", "path": "/data/$2"}]" | yq -o=json --indent=0 e - )
     if [[ $3 == '--dry-run' ]]; then
       echo "$PATCH" | yq e -P 'sort_keys(..)' -
     else
       set -x
-      kubectl patch $CHAINS_CONFIG --type=json -p='[{"op": "remove", "path":"'"/data/$2"'"}]'
+      kubectl patch $CHAINS_CONFIG --type=json --patch $PATCH 
       $0 restart-controller
       $0 get
     fi


### PR DESCRIPTION
This commit provides functionality to enable / disable a local
cluster installation with chains by specifying either 'rekor-local'
or 'rekor-default' when calling config.sh