### PR TITLE
ClusterTasks for cosign verify, verify-attestation

### DIFF
--- a/hack/chains/_helpers.sh
+++ b/hack/chains/_helpers.sh
@@ -122,3 +122,19 @@ curl-json() {
 trim-name() {
   echo "$1" | sed 's#.*/##'
 }
+
+#------------------------------------------------
+# Tekton utilities
+#------------------------------------------------
+
+#
+# Last TaskRun or ClusterTaskRun name of a provided named task
+#
+tkn-last-taskrun() {
+  local TASK_NAME=$1
+  TASKRUN_NAME=$(tkn taskrun list -o name --label "tekton.dev/task=$TASK_NAME" --limit 1 -o=go-template='{{range .items}}{{.metadata.name}}{{end}}')
+  if [[ -z $TASKRUN_NAME ]]; then
+    TASKRUN_NAME=$(tkn taskrun list -o name --label "tekton.dev/clusterTask=$TASK_NAME" --limit 1 -o=go-template='{{range .items}}{{.metadata.name}}{{end}}')
+  fi
+  echo $TASKRUN_NAME
+}

--- a/hack/chains/cosign-verify-tasks.yaml
+++ b/hack/chains/cosign-verify-tasks.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  annotations:
+    tekton.dev/displayName: cosign verify
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: cosign, chains, signature
+  labels:
+    app.kubernetes.io/version: "0.1"
+    operator.tekton.dev/provider-type: redhat
+  name: cosign-verify
+spec:
+  description: cosign-verify verifies the signature of the image reference with the provided public key.
+  params:
+  - description: Public key used to verify the signature. Points to a Secret containing `cosign.pub` key.
+    name: PUBLIC_KEY_NAME
+    type: string
+    default: signing-secrets
+  - description: Pull reference of the image to verify.
+    name: IMAGE
+    type: string
+  results:
+    - name: VERIFY_JSON
+      description: Result of verification in JSON format
+  steps:
+  - script: |
+      #!/usr/bin/env bash
+      cosign verify --output-file $(results.VERIFY_JSON.path) --key <(echo "$PUBLIC_KEY") $(params.IMAGE)
+    image: quay.io/redhat-appstudio/appstudio-utils:fc65477f443133e59f614a206e14c839a6498aff
+    name: verify
+    env:
+    - name: PUBLIC_KEY
+      valueFrom:
+        secretKeyRef:
+          name: $(params.PUBLIC_KEY_NAME)
+          key: cosign.pub
+    volumeMounts:
+    - name: ca-certificates
+      mountPath: /etc/ssl/certs/
+  volumes:
+  - name: ca-certificates
+    secret:
+      secretName: chains-ca-cert
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  annotations:
+    tekton.dev/displayName: cosign verify attestation
+    tekton.dev/pipelines.minVersion: "0.19"
+    tekton.dev/tags: cosign, chains, attestation
+  labels:
+    app.kubernetes.io/version: "0.1"
+    operator.tekton.dev/provider-type: redhat
+  name: cosign-verify-attestation
+spec:
+  description: cosign-verify-attestation verifies the attestation of the image reference with the provided public key.
+  params:
+  - description: Public key used to verify the signature. Points to a Secret containing `cosign.pub` key.
+    name: PUBLIC_KEY_NAME
+    type: string
+    default: signing-secrets
+  - description: Pull reference of the image to verify.
+    name: IMAGE
+    type: string
+  results:
+    - name: VERIFY_JSON
+      description: Result of verification in JSON format
+  steps:
+  - script: |
+      #!/usr/bin/env bash
+      cosign verify-attestation --output-file $(results.VERIFY_JSON.path) --key <(echo "$PUBLIC_KEY") $(params.IMAGE)
+    image: quay.io/redhat-appstudio/appstudio-utils:fc65477f443133e59f614a206e14c839a6498aff
+    name: verify
+    env:
+    - name: PUBLIC_KEY
+      valueFrom:
+        secretKeyRef:
+          name: $(params.PUBLIC_KEY_NAME)
+          key: cosign.pub
+    volumeMounts:
+    - name: ca-certificates
+      mountPath: /etc/ssl/certs/
+  volumes:
+  - name: ca-certificates
+    secret:
+      secretName: chains-ca-cert

--- a/hack/chains/kaniko-cosign-verify.sh
+++ b/hack/chains/kaniko-cosign-verify.sh
@@ -4,20 +4,15 @@ source $(dirname $0)/_helpers.sh
 set -ue
 
 # Use a specific taskrun if provided, otherwise use the latest
-TASKRUN_NAME=${1:-$( tkn taskrun describe --last -o name )}
-TASKRUN_NAME=taskrun/$( echo $TASKRUN_NAME | sed 's#.*/##' )
+TASKRUN_NAME=taskrun/${1:-$( tkn-last-taskrun kaniko-chains )}
 
 # Let's not hard code the image url or the registry
 IMAGE_URL=$( oc get $TASKRUN_NAME -o json | jq -r '.status.taskResults[1].value' )
 IMAGE_REGISTRY=$( echo $IMAGE_URL | cut -d/ -f1 )
 #IMAGE_REGISTRY=$( oc registry info )
+IS_REGISTRY_INTERNAL=$([[ $IMAGE_REGISTRY = image-registry.openshift-image-registry.svc* ]] && echo true)
 
 SIG_KEY="k8s://tekton-chains/signing-secrets"
-
-title "Make sure we're logged in to the registry"
-# Make sure we have a docker credential since cosign will need it
-# (Todo: Probably shouldn't assume kubeadmin user here)
-oc whoami -t | docker login -u kubeadmin --password-stdin $IMAGE_REGISTRY
 
 title "Inspect $TASKRUN_NAME annotations"
 # Just want to show the chains related fields
@@ -31,15 +26,34 @@ title "Image digest from task result"
 kubectl get $TASKRUN_NAME -o jsonpath="{.status.taskResults[?(@.name == \"IMAGE_DIGEST\")].value}"
 echo
 
+if $IS_REGISTRY_INTERNAL; then
+  oc create -f "$HACK_CHAINS/cosign-verify-tasks.yaml" 2>&1 | grep -q 'already exists' && oc replace -f "$HACK_CHAINS/cosign-verify-tasks.yaml"
+fi
+
 title "Cosign verify the image"
-# Save the output data to a file so we can look at it later
-# (Actually we could just pipe it to jq because the text goes to stderr I think..?)
-show-then-run "cosign verify --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify.out"
+if $IS_REGISTRY_INTERNAL; then
+  show-then-run tkn clustertask start cosign-verify -p IMAGE=$IMAGE_URL --use-param-defaults --showlog
+  tkn taskrun describe -o=go-template='{{range .status.taskResults}}{{if eq .name "VERIFY_JSON"}}{{.value}}{{end}}{{end}}' $(tkn-last-taskrun cosign-verify) > /tmp/verify.out
+else
+  title "Make sure we're logged in to the registry"
+  # Make sure we have a docker credential since cosign will need it
+  # (Todo: Probably shouldn't assume kubeadmin user here)
+  oc whoami -t | docker login -u kubeadmin --password-stdin $IMAGE_REGISTRY
+
+  # Save the output data to a file so we can look at it later
+  # (Actually we could just pipe it to jq because the text goes to stderr I think..?)
+  show-then-run "cosign verify --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify.out"
+fi
 yq e -P /tmp/verify.out
 pause
 
 title "Cosign verify the image's attestation"
-show-then-run "cosign verify-attestation --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify-att.out"
+if $IS_REGISTRY_INTERNAL; then
+  show-then-run tkn clustertask start cosign-verify-attestation -p IMAGE=$IMAGE_URL --use-param-defaults --showlog
+  tkn taskrun describe -o=go-template='{{range .status.taskResults}}{{if eq .name "VERIFY_JSON"}}{{.value}}{{end}}{{end}}' $(tkn-last-taskrun cosign-verify-attestation) > /tmp/verify-att.out
+else
+  show-then-run "cosign verify-attestation --key $SIG_KEY $IMAGE_URL --output-file /tmp/verify-att.out"
+fi
 # There can be multiple attestations for some reason and hence multiple lines in
 # this file, which makes it invalid json. For the sake of the demo we'll ignore
 # all but the last line.

--- a/hack/chains/kaniko-demo.sh
+++ b/hack/chains/kaniko-demo.sh
@@ -41,9 +41,9 @@ title "Wait a few seconds for chains finalizers to complete"
 sleep 10
 
 # This will use cosign to verify the new build
-$SCRIPTDIR/kaniko-cosign-verify.sh
+$SCRIPTDIR/kaniko-cosign-verify.sh $( tkn-last-taskrun kaniko-chains )
 
 pause
 
 # This will use rekor-cli to verify the new build
-$SCRIPTDIR/rekor-verify-taskrun.sh
+$SCRIPTDIR/rekor-verify-taskrun.sh $( tkn-last-taskrun kaniko-chains )


### PR DESCRIPTION
This adds two ClusterTasks to run `cosign verify` and
`cosign verify-attestation` as Tekton tasks, i.e. within the cluster.

The Kaniko demo script is changed to illustrate running these tasks if
the image is pushed to the internal OpenShift registry, this is just a
shortcut, we could use a parameter or run both on the end user computer
and on the cluster.

Further work should include rebasing this on
redhat-appstudio/build-definitions#28 and figure out if these tasks
should be part of `components/build` tasks.

Ref. https://issues.redhat.com/browse/HACBS-106

Also includes:

[Helper to get the last (Cluster)TaskRun by type](https://github.com/hacbs-contract/infra-deployments/commit/7833766bebfd87b46c973fc067ec8563afaef53f)

Adds `tkn-last-taskrun` function that takes the name of the
(Cluster)Task and returns the last (Cluster)TaskRun for it. The only
novel idea here is that as an alternative to using `yq` this golang
template is used instead.